### PR TITLE
Change cmd2 version specification to exact match

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ tabulate>=0.8.9
 validators>=0.18.2,<=0.20.0 # Future versions consider http://localhost as invalid
 spinners>=0.0.24
 termcolor>=1.1.0
-cmd2>=2.3.0
+cmd2==2.3.0
 log-symbols>=0.0.14
 arrow>=1.1.0
 py-sneakers>=1.0.1


### PR DESCRIPTION
cmd2>=2.3.0 generated the following error:

```
Traceback (most recent call last):
  File "/home/user/venv/bin/faraday-cli", line 5, in <module>
    from faraday_cli.shell.main import main
  File "/home/user/venv/lib/python3.12/site-packages/faraday_cli/shell/main.py", line 4, in <module>
    from faraday_cli.shell.shell import FaradayShell
  File "/home/user/venv/lib/python3.12/site-packages/faraday_cli/shell/shell.py", line 15, in <module>
    from cmd2 import (
ImportError: cannot import name 'style' from 'cmd2' (/home/user/venv/lib/python3.12/site-packages/cmd2/__init__.py). Did you mean: 'styles'?
```

changed to exact version match to be functional at least.